### PR TITLE
update links

### DIFF
--- a/ai_prompt_gen/ai_prompt.md
+++ b/ai_prompt_gen/ai_prompt.md
@@ -2061,7 +2061,8 @@ sidebar_position: 1
 
 # 模式介绍
 
-Open LLM VTuber 提供了三种使用模式，以满足不同用户的需求：[Web 模式](web-window-mode)、[窗口模式](web-window-mode)和[桌宠模式](pet-mode)。
+Open LLM VTuber 提供了三种使用模式，以满足不同用户的需求：[Web 模式](web)、[窗口模式](electron)和[桌宠模式](electron)。
+
 
 三种模式都使用 localStorage 来存储用户的个性化设置。
 

--- a/docs/user-guide/frontend/mode.md
+++ b/docs/user-guide/frontend/mode.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # 模式介绍
 
-Open LLM VTuber 提供了三种使用模式，以满足不同用户的需求：[Web 模式](web-window-mode)、[窗口模式](web-window-mode)和[桌宠模式](pet-mode)。
+Open LLM VTuber 提供了三种使用模式，以满足不同用户的需求：[Web 模式](web)、[窗口模式](electron)和[桌宠模式](electron)。
 
 三种模式都使用 localStorage 来存储用户的个性化设置。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/user-guide/frontend/mode.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user-guide/frontend/mode.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Mode Introduction
 
-Open LLM VTuber offers three modes of use to meet the needs of different users: [Web Mode](web-window-mode), [Window Mode](web-window-mode), and [Desktop Pet Mode](pet-mode).
+Open LLM VTuber offers three modes of use to meet the needs of different users: [Web Mode](web), [Window Mode](web), and [Desktop Pet Mode](pet).
 
 All three modes use localStorage to store user personalization settings.
 


### PR DESCRIPTION
Updated the links for different usage modes in markdown files:
- Changed "Web 模式" link from `web-window-mode` to `web`
- Changed "窗口模式" link from `web-window-mode` to `electron`
- Changed "桌宠模式" link from `pet-mode` to `electron`
